### PR TITLE
Gitignore .packages files.

### DIFF
--- a/dart-github-dart-lang/.gitignore
+++ b/dart-github-dart-lang/.gitignore
@@ -5,4 +5,5 @@
 .settings/
 build/
 packages
+.packages
 pubspec.lock

--- a/dart-github-google/.gitignore
+++ b/dart-github-google/.gitignore
@@ -5,4 +5,5 @@
 .settings/
 build/
 packages
+.packages
 pubspec.lock


### PR DESCRIPTION
As of 1.12, pub will start generating these files on all installs.