### PR TITLE
Encourage people to release 1.0.0 first

### DIFF
--- a/dart-github-dart-lang/CHANGELOG.md
+++ b/dart-github-dart-lang/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.1.0
+## 1.0.0
 
 * Initial version.

--- a/dart-github-dart-lang/pubspec.yaml
+++ b/dart-github-dart-lang/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sample
-version: 0.1.0-dev
+version: 1.0.0-dev
 description: A sample library.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/sample

--- a/dart-github-google/CHANGELOG.md
+++ b/dart-github-google/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.1.0
+## 1.0.0
 
 * Initial version.

--- a/dart-github-google/pubspec.yaml
+++ b/dart-github-google/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sample
-version: 0.1.0-dev
+version: 1.0.0-dev
 description: A sample library.
 author: Foo Bar <foobar@example.com>
 homepage: https://github.com/google/sample


### PR DESCRIPTION
Unless there's a good reason to think that the first release of a
package is unstable, it should be released as 1.0.0.